### PR TITLE
fix missing header sys/sysctl.h

### DIFF
--- a/src/Unique.cpp
+++ b/src/Unique.cpp
@@ -4,7 +4,11 @@
 #include <limits.h>
 #include <signal.h>
 #include <sys/sem.h>
+
+#if HAVE_SYSCTL
 #include <sys/sysctl.h>
+#endif
+
 #include <sys/types.h>
 
 #include "Unique.hpp"


### PR DESCRIPTION
sys/sysctl.h does not exist anymore.
Details:
https://sourceware.org/pipermail/glibc-cvs/2020q2/069366.html