### PR TITLE
Add `mainwindow_postion = topleft` etc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Code and stuff:
  * Unit 193
  * yauhen-l
  * dionisiovj
+ * Kent Friis
 
 Bugs and ideas:
  * Sergei Sarbash <sarbash.s@gmail.com>

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -63,6 +63,7 @@ void Config::setDefaults()
     mainwindow_sticky = false;
     mainwindow_skip_taskbar = true;
     mainwindow_position = GTK_WIN_POS_MOUSE;
+    mainwindow_gravity = GdkGravity(0);
     mainwindow_xoffset = 0;
     mainwindow_yoffset = 0;
     mark_today = true;
@@ -163,6 +164,14 @@ void Config::addOption(string var, string val)
             mainwindow_position = GTK_WIN_POS_CENTER;
         } else if (val == "mouse") {
             mainwindow_position = GTK_WIN_POS_MOUSE;
+        } else if (val == "topleft") {
+            mainwindow_gravity = GDK_GRAVITY_NORTH_WEST;
+        } else if (val == "topright") {
+            mainwindow_gravity = GDK_GRAVITY_NORTH_EAST;
+        } else if (val == "bottomleft") {
+            mainwindow_gravity = GDK_GRAVITY_SOUTH_WEST;
+        } else if (val == "bottomright") {
+            mainwindow_gravity = GDK_GRAVITY_SOUTH_EAST;
         } else {
             mainwindow_position = GTK_WIN_POS_NONE;
         }

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -37,6 +37,7 @@ public:
     bool mainwindow_sticky;
     bool mainwindow_skip_taskbar;
     bool mainwindow_resizable;
+    GdkGravity mainwindow_gravity;
     GtkWindowPosition mainwindow_position;
     int mainwindow_xoffset;
     int mainwindow_yoffset;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -98,9 +98,6 @@ MainWindow::MainWindow()
 
     gtk_window_set_title(GTK_WINDOW(widget), "gsimplecal");
     gtk_window_set_decorated(GTK_WINDOW(widget), config->mainwindow_decorated);
-    gtk_window_set_position(GTK_WINDOW(widget), config->mainwindow_position);
-    gtk_window_get_position(GTK_WINDOW(widget), &xpos, &ypos);
-    gtk_window_move(GTK_WINDOW(widget),  config->mainwindow_xoffset + xpos,  config->mainwindow_yoffset + ypos);
     gtk_window_set_resizable(GTK_WINDOW(widget), config->mainwindow_resizable);
     gtk_window_set_keep_above(GTK_WINDOW(widget),
                               config->mainwindow_keep_above);
@@ -131,6 +128,37 @@ MainWindow::MainWindow()
 
     gtk_container_add(GTK_CONTAINER(widget), children_box);
     gtk_widget_show(children_box);
+
+    if (config->mainwindow_gravity) {
+        gtk_window_get_size(GTK_WINDOW(widget), &xpos, &ypos);
+        switch(config->mainwindow_gravity) {
+            case GDK_GRAVITY_NORTH_WEST:
+                xpos = config->mainwindow_xoffset;
+                ypos = config->mainwindow_yoffset;
+                break;
+            case GDK_GRAVITY_NORTH_EAST:
+                xpos = gdk_screen_width() - xpos - config->mainwindow_xoffset;
+                ypos = config->mainwindow_yoffset;
+                break;
+            case GDK_GRAVITY_SOUTH_WEST:
+                xpos = config->mainwindow_xoffset;
+                ypos = gdk_screen_height() - ypos - config->mainwindow_yoffset;
+                break;
+            case GDK_GRAVITY_SOUTH_EAST:
+                xpos = gdk_screen_width() - xpos - config->mainwindow_xoffset;
+                ypos = gdk_screen_height() - ypos - config->mainwindow_yoffset;
+                break;
+        }
+        gtk_window_set_gravity(GTK_WINDOW(widget), config->mainwindow_gravity);
+        gtk_window_move(GTK_WINDOW(widget), xpos, ypos);
+    } else {
+        gtk_window_set_position(GTK_WINDOW(widget), config->mainwindow_position);
+        gtk_window_get_position(GTK_WINDOW(widget), &xpos, &ypos);
+        gtk_window_move(GTK_WINDOW(widget),
+                        config->mainwindow_xoffset + xpos,
+                        config->mainwindow_yoffset + ypos);
+    }
+
     gtk_widget_show(widget);
 
     // Connect keyboard accelerators


### PR DESCRIPTION
Got this patch in email from Kent Friis.

Unfortunately it currently raises a bunch of warnings that `gdk_screen_width` and `gdk_screen_height` are deprecated when compiling against gtk3.

So far we got

> apparently you are supposed to use `gdk_monitor_get_workarea()`, which doesn't even exist in the gtk 3.18 on Slackware, so it's not even a case of if(gtk2), it's before gtk 3.22 and after gtk 3.22

I've been putting this off for a while because I've got no time for this, unfortunately. Opening a pull request for this to not get lost forever.

If anyone has any input, please comment.