### PR TITLE
Add external viewer keyboard shortcut

### DIFF
--- a/doc/gsimplecal.1
+++ b/doc/gsimplecal.1
@@ -253,6 +253,10 @@ focus (not yet configurable):
 Close the window.
 
 .TP 5
+\fBReturn\fP
+Run the external viewer on the selected day.
+
+.TP 5
 \fBn\fP
 Switch to the next month.
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -16,6 +16,14 @@ bool closeCallback(GtkAccelGroup *group, GObject *obj, guint keyval,
     }
     return true;
 }
+bool runExternalViewerCallback(GtkAccelGroup *group, GObject *obj, guint keyval,
+                               GdkModifierType mod, gpointer user_data)
+{
+    if (user_data) {
+        ((MainWindow*)user_data)->runExternalViewer();
+    }
+    return true;
+}
 bool nextYearCallback(GtkAccelGroup *group, GObject *obj, guint keyval,
                       GdkModifierType mod, gpointer user_data)
 {
@@ -138,6 +146,7 @@ MainWindow::MainWindow()
     GClosure *closure;
 
     Shortcut keys[] = {{GDK_KEY_Escape, 0, closeCallback},
+                       {GDK_KEY_Return, 0, runExternalViewerCallback},
                        {GDK_KEY_q, GDK_CONTROL_MASK, closeCallback},
                        {GDK_KEY_w, GDK_CONTROL_MASK, closeCallback},
                        {GDK_KEY_n, GDK_SHIFT_MASK, nextYearCallback},
@@ -190,6 +199,10 @@ void MainWindow::close()
     g_signal_emit_by_name(widget, "destroy");
 }
 
+void MainWindow::runExternalViewer()
+{
+    calendar->runExternalViewer();
+}
 void MainWindow::goToday()
 {
     calendar->goToday();

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -18,6 +18,7 @@ public:
 
     void close();
 
+    void runExternalViewer();
     void nextMonth();
     void prevMonth();
     void nextYear();


### PR DESCRIPTION
I've been using this calendar for a couple of days now and I've noticed that the external viewer command wasn't mapped to any keyboard shortcut.
Given, that its interface is overall pretty well suited for a keyboard-driven workflow, I think it is only natural to map such action to some key, e.g. the return key (like launching something from a file explorer).

