### PR TITLE
Added close_on_mouseleave option

### DIFF
--- a/doc/gsimplecal.1
+++ b/doc/gsimplecal.1
@@ -79,6 +79,8 @@ show_week_numbers = 0
 .br
 close_on_unfocus = 0
 .br
+close_on_mouseleave = 0
+.br
 external_viewer = sunbird \-showdate "%Y\-%m\-%d"
 .br
 clock_format = %a %d %b %H:%M
@@ -149,6 +151,10 @@ Sets whether week numbers are shown in the calendar.
 Sets whether the calendar will close if the window loses focus. Note that if
 mainwindow_skip_taskbar is set to 1 then the calendar window may not be given
 focus upon creation
+
+.TP 5
+\fBclose_on_mouseleave\fP: 1 or 0, defaults to 0.
+Sets whether the calendar will close if the mouse pointer leaves the window.
 
 .TP 5
 \fBexternal_viewer\fP: string, defaults to empty string.

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -68,6 +68,7 @@ void Config::setDefaults()
     mark_today = true;
     show_week_numbers = false;
     close_on_unfocus = false;
+    close_on_mouseleave = false;
 }
 
 bool Config::findPath()
@@ -193,6 +194,10 @@ void Config::addOption(string var, string val)
     } else if (var == "close_on_unfocus") {
         if (!fromString<bool>(close_on_unfocus, val)) {
             close_on_unfocus = false;
+        }
+    } else if (var == "close_on_mouseleave") {
+        if (!fromString<bool>(close_on_mouseleave, val)) {
+            close_on_mouseleave = false;
         }
     } else if (var == "force_lang") {
         force_lang = val;

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -30,6 +30,7 @@ public:
     string external_viewer;
     bool show_week_numbers;
     bool close_on_unfocus;
+    bool close_on_mouseleave;
     string force_lang;
 
     bool mainwindow_decorated;

--- a/src/gsimplecal.cpp
+++ b/src/gsimplecal.cpp
@@ -122,6 +122,11 @@ int main(int argc, char *argv[])
                          GCallback(gtk_widget_destroy),
                          main_window->getWindow());
     }
+    if (config->close_on_mouseleave) {
+        g_signal_connect(main_window->getWindow(), "leave-notify-event",
+                         GCallback(gtk_widget_destroy),
+                         main_window->getWindow());
+    }
 
     gtk_main();
 


### PR DESCRIPTION
With this option, the window will close only when the mouse leaves the calendar window.
There is a similar option `close_on_unfocus` which closes the window when it loses focus. The problem is that the window gains focus when it gets created and when the user first drags the mouse pointer over other windows before reaching the calendar window, the calendar closes. This happens when the window manager is set to automatically focus windows when the mouse pointer hovers over them.